### PR TITLE
Remove duplicate PartialOrd impl for MonthMapKey

### DIFF
--- a/localnative-rs/localnative_iced/src/chart.rs
+++ b/localnative-rs/localnative_iced/src/chart.rs
@@ -353,12 +353,6 @@ impl Ord for MonthMapKey {
     }
 }
 
-impl PartialOrd for MonthMapKey {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
 #[derive(Clone, Debug)]
 enum ChartState {
     Daily(InnerState<RangedDate<NaiveDate>, NaiveDate>),


### PR DESCRIPTION
The same PartialOrd implementation was defined twice (lines 341 and 356),
causing a compilation error E0119. Removed the second duplicate.

https://claude.ai/code/session_01KNg43E7MzfDtJAGvo6sBHm