### PR TITLE
ci(tauri): bump Node to 20 for @sveltejs/vite-plugin-svelte

### DIFF
--- a/.github/workflows/localnative-tauri.yml
+++ b/.github/workflows/localnative-tauri.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
           cache-dependency-path: localnative-tauri/yarn.lock
       - name: Install Rust stable
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
           cache-dependency-path: localnative-tauri/yarn.lock
       - name: Install Rust stable


### PR DESCRIPTION
The Tauri CI failed at yarn install because @sveltejs/vite-plugin-svelte@7.1.2
requires Node ^20.19 || ^22.12 || >=24, but the workflow pinned Node 18.
Bump both the build and publish jobs to Node 20 (matching the website workflow).

https://claude.ai/code/session_01NDHUDCbVVVJb3NSbBMVCke