### PR TITLE
docs: document import/export and correct encryption flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,14 @@ This is **synchronous `rusqlite`** (bundled SQLite) with an **`r2d2` / `r2d2_sql
 - `queries` — the actual SQL/CRUD, search, filtering, tag aggregation.
 - `migrations` — version-keyed migration table (`MIGRATIONS: [(semver::Version, fn)]`) run automatically by `migrations::upgrade` on every `init_db`/`init_pool`. Schema history: 0.4.0 → 0.9.0, including the move to **FTS5** full-text search (`migrate_fts5`, later `migrate_fts5_trigram`). To change the schema, append a new `(Version, migrate_fn)` entry — do **not** hand-edit existing migrations.
 - `sync` — note diffing/merge logic used by RPC.
-- `encryption` — optional **SQLCipher** support. Disabled by default; enable by switching the `rusqlite` feature from `bundled` to `bundled-sqlcipher` in `localnative-rs/Cargo.toml`, then connections are unlocked via `init_db_encrypted(key)`.
+- `encryption` — optional **SQLCipher** support, gated behind `#[cfg(feature = "encryption")]`. Disabled by default; enabling it requires **both** the `localnative_core` `encryption` cargo feature **and** switching the `rusqlite` feature from `bundled` to `bundled-sqlcipher` in `localnative-rs/Cargo.toml`. The module exposes `init_db_encrypted(key)` (open + unlock + migrate), `set_encryption_key` (apply `PRAGMA key`, must run first on a connection), and `change_encryption_key` (`PRAGMA rekey`).
 
 Notes carry: title, URL, tags, description, comments, annotations (binary), timestamps, a UUID4, and a public/private flag.
+
+### Import / Export (`localnative_core/src/import.rs`, `export.rs`)
+Standalone core modules (not part of the JSON `Cmd` dispatch) driven by dedicated CLI binaries:
+- `import.rs` parses external sources into `ImportedNote`s and bulk-inserts them with URL-based de-duplication (`import_notes`): Pocket HTML (`parse_pocket_html`), Omnivore JSON (`parse_omnivore_json`), Raindrop CSV (`parse_raindrop_csv`), Plinky JSON (`parse_plinky_json`).
+- `export.rs` writes notes out as individual Markdown files with YAML frontmatter (`export_notes`), slugifying titles into filename-safe names.
 
 ### RPC / Sync (`localnative_core/src/rpc.rs`, `discovery.rs`)
 - **tarpc** peer-to-peer sync. Any client can `start` a server; others `sync` against it. Bi-directional, UUID-based conflict resolution; UUID lists are compared to decide what to transfer. Version compatibility is checked before transfer.
@@ -49,9 +54,15 @@ cd localnative-rs
 
 cargo build                      # build the workspace
 cargo run -p localnative_iced    # run the native GUI
-cargo run -p localnative_cli     # run the CLI
 cargo test                       # run all tests
 cargo test test_serde            # run a single test by name
+
+# localnative_cli ships several binaries (src/bin/), not one — select with --bin:
+cargo run -p localnative_cli --bin localnative-web-ext-host          # browser-extension native-messaging host
+cargo run -p localnative_cli --bin localnative-import -- <args>      # import Pocket/Omnivore/Raindrop/Plinky
+cargo run -p localnative_cli --bin localnative-export -- <args>      # export notes to Markdown
+# other bins: localnative-rpc-server, localnative-rpc-client-sync,
+#             localnative-rpc-client-stop-server, localnative-upgrade
 
 # CI-equivalent lint/format gate (matches .gitlab-ci.yml / xtask header):
 cargo fmt --all -- --check

--- a/website/docs/developer-setup.md
+++ b/website/docs/developer-setup.md
@@ -18,7 +18,7 @@ web-ext run --verbose # firefox
 ```
 
 #### Setup browser extension host binary
-- Download and run the desktop applcation from [release archive](https://gitlab.com/localnative/localnative-release)
+- Download and run the desktop application from [release archive](https://gitlab.com/localnative/localnative-release)
 
     this will create `~/LocalNative/bin` directory containing the host binary
 - or use `cargo install localnative_cli`, and find the binary at `~/.cargo/bin/localnative-web-ext-host`
@@ -117,6 +117,29 @@ make bridge       # regenerate Dart↔Rust bindings
 make run-android  # or run-ios / run-macos
 ```
 See `localnative-flutter/SETUP.md` for prerequisites (Flutter SDK, NDK, Xcode).
+
+## Import / Export
+
+Local Native ships dedicated CLI binaries (in `localnative_cli`) for moving notes
+in and out of the local SQLite database. Both operate on the database at the
+default location (`~/.ssb/localnative.sqlite3`).
+
+#### Import from another service
+Supported formats: `pocket` (HTML export), `omnivore` (JSON), `raindrop` (CSV),
+`plinky` (JSON). Notes are de-duplicated by URL, so re-running an import is safe.
+```
+cd localnative-rs
+cargo run -p localnative_cli --bin localnative-import -- --format pocket path/to/export.html
+```
+
+#### Export to Markdown
+Exports each note as an individual `.md` file with YAML frontmatter. An optional
+search query filters which notes are exported.
+```
+cd localnative-rs
+cargo run -p localnative_cli --bin localnative-export -- --output ./exported-notes
+cargo run -p localnative_cli --bin localnative-export -- --output ./exported-notes --query rust
+```
 
 ## Script
 There are scripts to bump version and release


### PR DESCRIPTION
- CLAUDE.md: fix encryption section to note the `encryption` cargo
  feature is required alongside `bundled-sqlcipher`, and list the
  actual API (init_db_encrypted/set_encryption_key/change_encryption_key)
- CLAUDE.md: add Import/Export core modules and their parsers/exporter
- CLAUDE.md: replace the ambiguous `cargo run -p localnative_cli` with
  the real per-binary invocations (localnative_cli ships several bins)
- website developer-setup: add Import/Export CLI usage, fix typo

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016J1MxjbTC2xK4eVTceqjpn